### PR TITLE
Allow adding a custom link to be added to _links portion of response

### DIFF
--- a/djangorestframework_hal/utils.py
+++ b/djangorestframework_hal/utils.py
@@ -62,6 +62,14 @@ def render_dict(json_dict, paginated=False) -> Embedded:
     if 'url' in links:
         links['self'] = links.pop('url')
 
+    links_to_change = []
+    for link in links:
+        if '_links' in link:
+            links_to_change.append(link)
+
+    for link in links_to_change:
+        links[link.replace('_links', '')] = links.pop(link)
+
     transformed_dict = OrderedDict()
     if links:
         transformed_dict['_links'] = links

--- a/djangorestframework_hal/utils.py
+++ b/djangorestframework_hal/utils.py
@@ -62,6 +62,8 @@ def render_dict(json_dict, paginated=False) -> Embedded:
     if 'url' in links:
         links['self'] = links.pop('url')
 
+    ###############################################################
+    # These lines of code are a hacky solution to solve a specific issue in a specific project
     links_to_change = []
     for link in links:
         if '_links' in link:
@@ -69,6 +71,7 @@ def render_dict(json_dict, paginated=False) -> Embedded:
 
     for link in links_to_change:
         links[link.replace('_links', '')] = links.pop(link)
+    ###############################################################
 
     transformed_dict = OrderedDict()
     if links:

--- a/tests/app/serializers.py
+++ b/tests/app/serializers.py
@@ -30,3 +30,27 @@ class BookUrlSerializer(FlexFieldsSerializerMixin, serializers.HyperlinkedModelS
                 'lookup_field': 'uuid',
             }
         }
+
+
+class BookUrlSerializerWithCustomLink(FlexFieldsSerializerMixin, serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Book
+        fields = ('url', 'title', 'pages', 'author')
+        expandable_fields = {
+            'author': AuthorUrlSerializer
+        }
+        extra_kwargs = {
+            'url': {
+                'lookup_field': 'uuid',
+            },
+            'author': {
+                'lookup_field': 'uuid',
+            }
+        }
+
+    def to_representation(self, *args, **kwargs):
+        representation = super().to_representation(*args, **kwargs)
+
+        representation['custom_links'] = 'http://custom.com/link'
+
+        return representation

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .viewsets import (
-    AuthorHalViewSet, AuthorViewSet, BookHalViewSet, BookViewSet
+    AuthorHalViewSet, AuthorViewSet, BookHalViewSet, BookViewSet, BookHalViewSetWithCustomLinkSerializer
 )
 
 router = DefaultRouter()
@@ -11,6 +11,7 @@ router.register(r'authors', AuthorViewSet)
 router.register(r'books', BookViewSet)
 router.register(r'authors_hal', AuthorHalViewSet)
 router.register(r'books_hal', BookHalViewSet)
+router.register(r'books_hal_custom', BookHalViewSetWithCustomLinkSerializer, basename='custom-book')
 
 urlpatterns = [
         # actual API

--- a/tests/app/viewsets.py
+++ b/tests/app/viewsets.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 from rest_framework.pagination import PageNumberPagination
 
 from .models import Author, Book
-from .serializers import AuthorUrlSerializer, BookUrlSerializer
+from .serializers import AuthorUrlSerializer, BookUrlSerializer, BookUrlSerializerWithCustomLink
 
 from djangorestframework_hal.renderers import HalJSONRenderer
 from djangorestframework_hal.parsers import HalJSONParser
@@ -41,3 +41,11 @@ class BookHalViewSet(viewsets.ModelViewSet):
     pagination_class = None
     lookup_field = 'uuid'
 
+
+class BookHalViewSetWithCustomLinkSerializer(viewsets.ModelViewSet):
+    queryset = Book.objects.all()
+    serializer_class = BookUrlSerializerWithCustomLink
+    renderer_classes = (HalJSONRenderer,)
+    parser_classes = (HalJSONParser,)
+    pagination_class = None
+    lookup_field = 'uuid'

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -76,6 +76,36 @@ class BookTests(APITestCase):
             }
         )
 
+    def test_book_retrieve_with_custom_url(self):
+        """
+        test /books/{id} GET:
+        """
+
+        author = Author.objects.create(name='Tolstoy')
+        book = Book.objects.create(author=author, pages=1000, title='War and peace')
+        book_url = reverse('custom-book-detail', args=[book.uuid])
+
+        response = self.client.get(book_url, HTTP_HOST='localhost')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        author_url = reverse('author-detail', kwargs={'uuid': author.uuid})
+        book_url = reverse('book-detail', kwargs={'uuid': book.uuid})
+
+        self.assertEqual(
+            data,
+            {
+                '_links': {
+                    'author': {'href': f'http://localhost{author_url}'},
+                    'self': {'href': f'http://localhost{book_url}'},
+                    'custom': {'href': 'http://custom.com/link'}
+                },
+                'title': 'War and peace',
+                'pages': 1000
+            }
+        )
+
     def test_book_list(self):
         """
         test /books GET:


### PR DESCRIPTION
This change allows adding custom links to the data that will be returned so that we can add custom links to the `_links` attribute of the json hal response.

The link should end with `_links` and this part will be stripped.  Eg. `custom_links` changes to `custom` in the `_links` property of the json hal response.